### PR TITLE
adjust log format in LogTradesAnalysis Analyze

### DIFF
--- a/analysis.go
+++ b/analysis.go
@@ -60,10 +60,16 @@ type LogTradesAnalysis struct {
 // Analyze logs trades to provided io.Writer
 func (lta LogTradesAnalysis) Analyze(record *TradingRecord) float64 {
 	logOrder := func(trade *Position) {
-		fmt.Fprintln(lta.Writer, fmt.Sprintf("%s - enter with buy %s (%s @ $%s)", trade.EntranceOrder().ExecutionTime.UTC().Format(time.RFC822), trade.EntranceOrder().Security, trade.EntranceOrder().Amount, trade.EntranceOrder().Price))
-		fmt.Fprintln(lta.Writer, fmt.Sprintf("%s - exit with sell %s (%s @ $%s)", trade.ExitOrder().ExecutionTime.UTC().Format(time.RFC822), trade.ExitOrder().Security, trade.ExitOrder().Amount, trade.ExitOrder().Price))
-
-		profit := trade.ExitValue().Sub(trade.CostBasis())
+		fmt.Fprintln(lta.Writer, fmt.Sprintf("%s - enter with %s %s (%s @ $%s)",
+			trade.EntranceOrder().ExecutionTime.Format(time.RFC822), trade.EntranceOrder().Side, trade.EntranceOrder().Security, trade.EntranceOrder().Amount, trade.EntranceOrder().Price))
+		fmt.Fprintln(lta.Writer, fmt.Sprintf("%s - exit with %s %s (%s @ $%s)",
+			trade.ExitOrder().ExecutionTime.Format(time.RFC822), trade.EntranceOrder().Side, trade.ExitOrder().Security, trade.ExitOrder().Amount, trade.ExitOrder().Price))
+		profit := big.ZERO
+		if trade.IsLong() {
+			profit = trade.ExitValue().Sub(trade.CostBasis())
+		} else {
+			profit = trade.CostBasis().Sub(trade.ExitValue())
+		}
 		fmt.Fprintln(lta.Writer, fmt.Sprintf("Profit: $%s", profit))
 	}
 

--- a/order.go
+++ b/order.go
@@ -15,6 +15,17 @@ const (
 	SELL
 )
 
+func (os OrderSide) String() string {
+	switch os {
+	case BUY:
+		return "BUY"
+	case SELL:
+		return "SELL"
+	default:
+		return "UNKNOWN"
+	}
+}
+
 // Order represents a trade execution (buy or sell) with associated metadata.
 type Order struct {
 	Side          OrderSide


### PR DESCRIPTION
use local time make more readability
add orderside string for trades analysis. because EntranceOrder may not be bought, but sold.
