### PR TITLE
Fix RSI calculation

### DIFF
--- a/indicator_relative_strength.go
+++ b/indicator_relative_strength.go
@@ -1,6 +1,8 @@
 package techan
 
 import (
+	"math"
+	
 	"github.com/sdcoffey/big"
 )
 
@@ -46,6 +48,10 @@ func NewRelativeStrengthIndicator(indicator Indicator, timeframe int) Indicator 
 func (rs relativeStrengthIndicator) Calculate(index int) big.Decimal {
 	avgGain := rs.avgGain.Calculate(index)
 	avgLoss := rs.avgLoss.Calculate(index)
+
+	if avgLoss.EQ(big.ZERO) {
+		return big.NewDecimal(math.MaxFloat64)
+	}
 
 	return avgGain.Div(avgLoss)
 }

--- a/indicator_relative_strength_test.go
+++ b/indicator_relative_strength_test.go
@@ -1,8 +1,10 @@
 package techan
 
 import (
+	"math"
 	"testing"
 
+	"github.com/sdcoffey/big"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -45,4 +47,10 @@ func TestRelativeStrengthIndicator(t *testing.T) {
 	indicator := NewRelativeStrengthIndicator(closeIndicator, 14)
 
 	assert.EqualValues(t, "2.39", indicator.Calculate(14).FormattedString(2))
+}
+
+func TestRelativeStrengthIndicatorNoPriceChange(t *testing.T) {
+	close := NewClosePriceIndicator(mockTimeSeries("42.0", "42.0"))
+	rsInd := NewRelativeStrengthIndicator(close, 2)
+	assert.Equal(t, big.NewDecimal(math.MaxFloat64).FormattedString(2), rsInd.Calculate(1).FormattedString(2))
 }


### PR DESCRIPTION
There's an edge case in RS calculation. The RS is calculated by `avgGain / avgLoss` and when `avgLoss` is 0, a divided by 0 error happens.

The proposed fix is to return a max float instead so the eventual RSI is calculated roughly to 100.