### PR TITLE
Ability to remove (to re-calc) cached calculations

### DIFF
--- a/indicator.go
+++ b/indicator.go
@@ -7,4 +7,5 @@ import "github.com/sdcoffey/big"
 // returns the current moving average of the prices in that series.
 type Indicator interface {
 	Calculate(int) big.Decimal
+	RemoveCachedEntry(int)
 }

--- a/indicator_aroon.go
+++ b/indicator_aroon.go
@@ -26,6 +26,10 @@ func (ai *aroonIndicator) Calculate(index int) big.Decimal {
 	return windowAsDecimal.Sub(pSince).Div(windowAsDecimal).Mul(oneHundred)
 }
 
+func (ai *aroonIndicator) RemoveCachedEntry(index int) {
+	ai.indicator.RemoveCachedEntry(index)
+}
+
 func (ai aroonIndicator) findLowIndex(index int) int {
 	if ai.lowIndex < 1 || ai.lowIndex < index-ai.window {
 		lv := big.NewDecimal(math.MaxFloat64)

--- a/indicator_basic.go
+++ b/indicator_basic.go
@@ -15,6 +15,10 @@ func (vi volumeIndicator) Calculate(index int) big.Decimal {
 	return vi.Candles[index].Volume
 }
 
+func (vi volumeIndicator) RemoveCachedEntry(index int) {
+	//No-Op
+}
+
 type closePriceIndicator struct {
 	*TimeSeries
 }
@@ -26,6 +30,10 @@ func NewClosePriceIndicator(series *TimeSeries) Indicator {
 
 func (cpi closePriceIndicator) Calculate(index int) big.Decimal {
 	return cpi.Candles[index].ClosePrice
+}
+
+func (cpi closePriceIndicator) RemoveCachedEntry(index int) {
+	//No-Op
 }
 
 type highPriceIndicator struct {
@@ -43,6 +51,10 @@ func (hpi highPriceIndicator) Calculate(index int) big.Decimal {
 	return hpi.Candles[index].MaxPrice
 }
 
+func (hpi highPriceIndicator) RemoveCachedEntry(index int) {
+	//No-Op
+}
+
 type lowPriceIndicator struct {
 	*TimeSeries
 }
@@ -56,6 +68,10 @@ func NewLowPriceIndicator(series *TimeSeries) Indicator {
 
 func (lpi lowPriceIndicator) Calculate(index int) big.Decimal {
 	return lpi.Candles[index].MinPrice
+}
+
+func (lpi lowPriceIndicator) RemoveCachedEntry(index int) {
+	//No-Op
 }
 
 type openPriceIndicator struct {
@@ -73,6 +89,10 @@ func (opi openPriceIndicator) Calculate(index int) big.Decimal {
 	return opi.Candles[index].OpenPrice
 }
 
+func (opi openPriceIndicator) RemoveCachedEntry(index int) {
+	//No-Op
+}
+
 type typicalPriceIndicator struct {
 	*TimeSeries
 }
@@ -86,4 +106,8 @@ func NewTypicalPriceIndicator(series *TimeSeries) Indicator {
 func (tpi typicalPriceIndicator) Calculate(index int) big.Decimal {
 	numerator := tpi.Candles[index].MaxPrice.Add(tpi.Candles[index].MinPrice).Add(tpi.Candles[index].ClosePrice)
 	return numerator.Div(big.NewFromString("3"))
+}
+
+func (tpi typicalPriceIndicator) RemoveCachedEntry(index int) {
+	//No-Op
 }

--- a/indicator_bollinger_band.go
+++ b/indicator_bollinger_band.go
@@ -31,3 +31,8 @@ func NewBollingerLowerBandIndicator(indicator Indicator, window int, sigma float
 func (bbi bbandIndicator) Calculate(index int) big.Decimal {
 	return bbi.ma.Calculate(index).Add(bbi.stdev.Calculate(index).Mul(bbi.muladd))
 }
+
+func (bbi bbandIndicator) RemoveCachedEntry(index int) {
+	bbi.ma.RemoveCachedEntry(index)
+	bbi.stdev.RemoveCachedEntry(index)
+}

--- a/indicator_cci.go
+++ b/indicator_cci.go
@@ -23,3 +23,7 @@ func (ccii commidityChannelIndexIndicator) Calculate(index int) big.Decimal {
 
 	return typicalPrice.Calculate(index).Sub(typicalPriceSma.Calculate(index)).Div(meanDeviation.Calculate(index).Mul(big.NewFromString("0.015")))
 }
+
+func (ccii commidityChannelIndexIndicator) RemoveCachedEntry(index int) {
+	//No-Op - since indicators are created directly within the Calculate function
+}

--- a/indicator_constant.go
+++ b/indicator_constant.go
@@ -13,3 +13,7 @@ func NewConstantIndicator(constant float64) Indicator {
 func (ci constantIndicator) Calculate(index int) big.Decimal {
 	return big.NewDecimal(float64(ci))
 }
+
+func (ci constantIndicator) RemoveCachedEntry(index int) {
+	//No-Op
+}

--- a/indicator_difference.go
+++ b/indicator_difference.go
@@ -19,3 +19,8 @@ func NewDifferenceIndicator(minuend, subtrahend Indicator) Indicator {
 func (di differenceIndicator) Calculate(index int) big.Decimal {
 	return di.minuend.Calculate(index).Sub(di.subtrahend.Calculate(index))
 }
+
+func (di differenceIndicator) RemoveCachedEntry(index int) {
+	di.minuend.RemoveCachedEntry(index)
+	di.subtrahend.RemoveCachedEntry(index)
+}

--- a/indicator_fixed.go
+++ b/indicator_fixed.go
@@ -12,3 +12,7 @@ func NewFixedIndicator(vals ...float64) Indicator {
 func (fi fixedIndicator) Calculate(index int) big.Decimal {
 	return big.NewDecimal(fi[index])
 }
+
+func (fi fixedIndicator) RemoveCachedEntry(index int) {
+	//No-Op
+}

--- a/indicator_maximum_drawdown.go
+++ b/indicator_maximum_drawdown.go
@@ -26,3 +26,7 @@ func (mdi maximumDrawdownIndicator) Calculate(index int) big.Decimal {
 
 	return (minVal.Sub(maxVal)).Div(maxVal)
 }
+
+func (mdi maximumDrawdownIndicator) RemoveCachedEntry(index int) {
+	mdi.indicator.RemoveCachedEntry(index)
+}

--- a/indicator_maximum_value.go
+++ b/indicator_maximum_value.go
@@ -34,3 +34,7 @@ func (mvi maximumValueIndicator) Calculate(index int) big.Decimal {
 
 	return maxValue
 }
+
+func (mvi maximumValueIndicator) RemoveCachedEntry(index int) {
+	mvi.indicator.RemoveCachedEntry(index)
+}

--- a/indicator_minimum_value.go
+++ b/indicator_minimum_value.go
@@ -34,3 +34,7 @@ func (mvi minimumValueIndicator) Calculate(index int) big.Decimal {
 
 	return minValue
 }
+
+func (mvi minimumValueIndicator) RemoveCachedEntry(index int) {
+	mvi.indicator.RemoveCachedEntry(index)
+}

--- a/indicator_moving_average.go
+++ b/indicator_moving_average.go
@@ -23,6 +23,10 @@ func (sma smaIndicator) Calculate(index int) big.Decimal {
 	return sum.Div(big.NewDecimal(float64(realwindow)))
 }
 
+func (sma smaIndicator) RemoveCachedEntry(index int) {
+	sma.indicator.RemoveCachedEntry(index)
+}
+
 type emaIndicator struct {
 	Indicator
 	window      int
@@ -51,16 +55,20 @@ func (ema *emaIndicator) Calculate(index int) big.Decimal {
 
 	emaPrev := ema.Calculate(index - 1)
 	result := ema.Indicator.Calculate(index).Sub(emaPrev).Mul(ema.alpha).Add(emaPrev)
-	ema.cacheResult(index, result)
+	ema.cacheResult(index, &result)
 
 	return result
 }
 
-func (ema *emaIndicator) cacheResult(index int, val big.Decimal) {
+func (ema *emaIndicator) RemoveCachedEntry(index int) {
+	ema.cacheResult(index, nil)
+}
+
+func (ema *emaIndicator) cacheResult(index int, val *big.Decimal) {
 	if index < len(ema.resultCache) {
-		ema.resultCache[index] = &val
+		ema.resultCache[index] = val
 	} else {
-		ema.resultCache = append(ema.resultCache, &val)
+		ema.resultCache = append(ema.resultCache, val)
 	}
 }
 

--- a/indicator_moving_average_test.go
+++ b/indicator_moving_average_test.go
@@ -62,6 +62,26 @@ func TestExponentialMovingAverage(t *testing.T) {
 
 		assert.EqualValues(t, 10001, len(ema.(*emaIndicator).resultCache))
 	})
+
+	t.Run("works after calling RemoveCacheEntry ", func(t *testing.T) {
+		ts := mockTimeSeriesFl(
+			64.75, 63.79, 63.73,
+			63.73, 63.55, 63.19,
+			63.91, 63.85, 62.95,
+			63.37, 61.33, 61.51)
+
+		ema := NewEMAIndicator(NewClosePriceIndicator(ts), 10)
+
+		decimalEquals(t, 63.6948, ema.Calculate(9))
+		decimalEquals(t, 63.2649, ema.Calculate(10))
+		decimalEquals(t, 62.9458, ema.Calculate(11))
+
+		ema.RemoveCachedEntry(10)
+
+		decimalEquals(t, 63.6948, ema.Calculate(9))
+		decimalEquals(t, 63.2649, ema.Calculate(10))
+		decimalEquals(t, 62.9458, ema.Calculate(11))
+	})
 }
 
 func TestNewMMAIndicator(t *testing.T) {
@@ -72,6 +92,12 @@ func TestNewMMAIndicator(t *testing.T) {
 		63.37, 61.33, 61.51)
 
 	mma := NewMMAIndicator(NewClosePriceIndicator(series), 10)
+
+	decimalEquals(t, 63.9983, mma.Calculate(9))
+	decimalEquals(t, 63.7315, mma.Calculate(10))
+	decimalEquals(t, 63.5094, mma.Calculate(11))
+
+	mma.RemoveCachedEntry(10)
 
 	decimalEquals(t, 63.9983, mma.Calculate(9))
 	decimalEquals(t, 63.7315, mma.Calculate(10))
@@ -95,7 +121,7 @@ func TestNewMACDHistogramIndicator(t *testing.T) {
 	assert.NotNil(t, macdHistogram)
 }
 
-func BenchmarkExponetialMovingAverage(b *testing.B) {
+func BenchmarkExponentialMovingAverage(b *testing.B) {
 	size := 10000
 	ts := randomTimeSeries(size)
 

--- a/indicator_relative_strength.go
+++ b/indicator_relative_strength.go
@@ -30,6 +30,10 @@ func (rsi relativeStrengthIndexIndicator) Calculate(index int) big.Decimal {
 	return oneHundred.Sub(oneHundred.Div(big.ONE.Add(relativeStrength)))
 }
 
+func (rsi relativeStrengthIndexIndicator) RemoveCachedEntry(index int) {
+	rsi.rsIndicator.RemoveCachedEntry(index)
+}
+
 type relativeStrengthIndicator struct {
 	avgGain Indicator
 	avgLoss Indicator
@@ -54,4 +58,9 @@ func (rs relativeStrengthIndicator) Calculate(index int) big.Decimal {
 	}
 
 	return avgGain.Div(avgLoss)
+}
+
+func (rs relativeStrengthIndicator) RemoveCachedEntry(index int) {
+	rs.avgGain.RemoveCachedEntry(index)
+	rs.avgLoss.RemoveCachedEntry(index)
 }

--- a/indicator_relative_vigor_index.go
+++ b/indicator_relative_vigor_index.go
@@ -42,6 +42,11 @@ func (rvii relativeVigorIndexIndicator) Calculate(index int) big.Decimal {
 	return num.Div(denom)
 }
 
+func (rvii relativeVigorIndexIndicator) RemoveCachedEntry(index int) {
+	rvii.numerator.RemoveCachedEntry(index)
+	rvii.denominator.RemoveCachedEntry(index)
+}
+
 type relativeVigorIndexSignalLine struct {
 	relativeVigorIndex Indicator
 }
@@ -65,4 +70,8 @@ func (rvsn relativeVigorIndexSignalLine) Calculate(index int) big.Decimal {
 	k := rvsn.relativeVigorIndex.Calculate(index - 3)
 
 	return (rvi.Add(i).Add(j).Add(k)).Div(big.NewFromString("6"))
+}
+
+func (rvsn relativeVigorIndexSignalLine) RemoveCachedEntry(index int) {
+	rvsn.relativeVigorIndex.RemoveCachedEntry(index)
 }

--- a/indicator_standard_deviation.go
+++ b/indicator_standard_deviation.go
@@ -20,3 +20,7 @@ type standardDeviationIndicator struct {
 func (sdi standardDeviationIndicator) Calculate(index int) big.Decimal {
 	return sdi.indicator.Calculate(index).Sqrt()
 }
+
+func (sdi standardDeviationIndicator) RemoveCachedEntry(index int) {
+	sdi.indicator.RemoveCachedEntry(index)
+}

--- a/indicator_trend.go
+++ b/indicator_trend.go
@@ -32,6 +32,10 @@ func (tli trendLineIndicator) Calculate(index int) big.Decimal {
 	return ab.Div(cd)
 }
 
+func (tli trendLineIndicator) RemoveCachedEntry(index int) {
+	tli.indicator.RemoveCachedEntry(index)
+}
+
 func sumX(decimals []big.Decimal) (s big.Decimal) {
 	s = big.ZERO
 

--- a/indicator_variance.go
+++ b/indicator_variance.go
@@ -6,12 +6,12 @@ import "github.com/sdcoffey/big"
 // deviations from the mean at any given index in the time series.
 func NewVarianceIndicator(ind Indicator) Indicator {
 	return varianceIndicator{
-		Indicator: ind,
+		indicator: ind,
 	}
 }
 
 type varianceIndicator struct {
-	Indicator Indicator
+	indicator Indicator
 }
 
 // Calculate returns the Variance for this indicator at the given index
@@ -20,14 +20,18 @@ func (vi varianceIndicator) Calculate(index int) big.Decimal {
 		return big.ZERO
 	}
 
-	avgIndicator := NewSimpleMovingAverage(vi.Indicator, index+1)
+	avgIndicator := NewSimpleMovingAverage(vi.indicator, index+1)
 	avg := avgIndicator.Calculate(index)
 	variance := big.ZERO
 
 	for i := 0; i <= index; i++ {
-		pow := vi.Indicator.Calculate(i).Sub(avg).Pow(2)
+		pow := vi.indicator.Calculate(i).Sub(avg).Pow(2)
 		variance = variance.Add(pow)
 	}
 
 	return variance.Div(big.NewDecimal(float64(index + 1)))
+}
+
+func (vi varianceIndicator) RemoveCachedEntry(index int) {
+	vi.indicator.RemoveCachedEntry(index)
 }


### PR DESCRIPTION
Not sure if this would be something that you're interested in, but I've found benefit from using the MACD Histogram with minute candles, where the last candle is updated based on sub-minute streamed values - i.e. the last candle is an approximation, but still provides value. It requires the ability to re-calculate (i.e. not use the cached value). 