### PR TITLE
Fix EMA calulation when window > 3

### DIFF
--- a/indicator_exponential_moving_average.go
+++ b/indicator_exponential_moving_average.go
@@ -29,7 +29,7 @@ func (ema *emaIndicator) Calculate(index int) big.Decimal {
 	}
 
 	todayVal := ema.indicator.Calculate(index).Mul(ema.alpha)
-	result := todayVal.Add(ema.Calculate(index - 1).Mul(ema.alpha))
+	result := todayVal.Add(ema.Calculate(index - 1).Mul(big.ONE.Sub(ema.alpha)))
 
 	cacheResult(ema, index, result)
 

--- a/indicator_exponential_moving_average_test.go
+++ b/indicator_exponential_moving_average_test.go
@@ -11,20 +11,20 @@ func TestExponentialMovingAverage(t *testing.T) {
 		expectedValues := []float64{
 			0,
 			0,
-			64.09,
-			63.91,
-			63.73,
-			63.46,
-			63.685,
-			63.7675,
-			63.3588,
-			63.3644,
-			62.3472,
-			61.9286,
+			0,
+			64,
+			63.82,
+			63.568,
+			63.7048,
+			63.7629,
+			63.4377,
+			63.4106,
+			62.5784,
+			62.151,
 		}
 
 		closePriceIndicator := NewClosePriceIndicator(mockedTimeSeries)
-		indicatorEquals(t, expectedValues, NewEMAIndicator(closePriceIndicator, 3))
+		indicatorEquals(t, expectedValues, NewEMAIndicator(closePriceIndicator, 4))
 	})
 
 	t.Run("Expands Result Cache", func(t *testing.T) {


### PR DESCRIPTION
There is a bug in EMA calculations when window is > 3. Consequently, the test case didn't pick it up as it only used a window of 3.

This PR fixes the EMA by correcting the (1 - alpha) component of the calculation as per https://www.investopedia.com/terms/e/ema.asp ..