### PR TITLE
Corrected EMA formula for window != 3

### DIFF
--- a/indicator_exponential_moving_average.go
+++ b/indicator_exponential_moving_average.go
@@ -29,7 +29,7 @@ func (ema *emaIndicator) Calculate(index int) big.Decimal {
 	}
 
 	todayVal := ema.indicator.Calculate(index).Mul(ema.alpha)
-	result := todayVal.Add(ema.Calculate(index - 1).Mul(ema.alpha))
+	result := todayVal.Add(ema.Calculate(index - 1).Mul(big.ONE.Sub(ema.alpha)))
 
 	cacheResult(ema, index, result)
 

--- a/indicator_exponential_moving_average_test.go
+++ b/indicator_exponential_moving_average_test.go
@@ -27,6 +27,26 @@ func TestExponentialMovingAverage(t *testing.T) {
 		indicatorEquals(t, expectedValues, NewEMAIndicator(closePriceIndicator, 3))
 	})
 
+	t.Run("Window Size 5", func(t *testing.T) {
+		expectedValues := []float64{
+			0,
+			0,
+			0,
+			0,
+			63.91,
+			63.67,
+			63.75,
+			63.7833,
+			63.5056,
+			63.4604,
+			62.7502,
+			62.3368,
+		}
+
+		closePriceIndicator := NewClosePriceIndicator(mockedTimeSeries)
+		indicatorEquals(t, expectedValues, NewEMAIndicator(closePriceIndicator, 5))
+	})
+
 	t.Run("Expands Result Cache", func(t *testing.T) {
 		closeIndicator := NewClosePriceIndicator(randomTimeSeries(1001))
 		ema := NewEMAIndicator(closeIndicator, 20)


### PR DESCRIPTION
According to
https://tlc.thinkorswim.com/center/reference/Tech-Indicators/studies-library/M-N/MovAvgExponential

The recursive formula for EMA is the following:

```
EMA_1 = price_1;
EMA_2 = α*price_2 + (1 - α)*EMA_1;
EMA_3 = α*price_3 + (1 - α)*EMA_2;
EMA_N = α*price_N + (1 - α)*EMA_N-1;
```

The original test didn't fail because with a window size of `3` the alpha value is `0.5` and therefore the formula was working in that case. I've added a test with a different window size that illustrates the problem.

Without this fix, the new test case fails with clearly incorrect values:
```
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -6,9 +6,9 @@
                                  (float64) 63.91,
                                - (float64) 63.67,
                                - (float64) 63.75,
                                - (float64) 63.7833,
                                - (float64) 63.5056,
                                - (float64) 63.4604,
                                - (float64) 62.7502,
                                - (float64) 62.3368
                                + (float64) 42.3667,
                                + (float64) 35.4256,
                                + (float64) 33.0919,
                                + (float64) 32.014,
                                + (float64) 31.7947,
                                + (float64) 31.0416,
                                + (float64) 30.8505
                                 }
```
