### PR TITLE
[codex] Make indicator test helper vet-safe

### DIFF
--- a/testutils.go
+++ b/testutils.go
@@ -88,24 +88,14 @@ func decimalEquals(t *testing.T, expected float64, actual big.Decimal) {
 	assert.Equal(t, fmt.Sprintf("%.4f", expected), fmt.Sprintf("%.4f", actual.Float()))
 }
 
-func dump(indicator Indicator) (values []float64) {
+func indicatorEquals(t *testing.T, expected []float64, indicator Indicator) {
 	precision := 4.0
 	m := math.Pow(10, precision)
 
-	defer func() {
-		recover()
-	}()
-
-	var index int
-	for {
-		values = append(values, math.Round(indicator.Calculate(index).Float()*m)/m)
-		index++
+	actualValues := make([]float64, len(expected))
+	for i := range expected {
+		actualValues[i] = math.Round(indicator.Calculate(i).Float()*m) / m
 	}
 
-	return
-}
-
-func indicatorEquals(t *testing.T, expected []float64, indicator Indicator) {
-	actualValues := dump(indicator)
 	assert.EqualValues(t, expected, actualValues)
 }


### PR DESCRIPTION
## Summary
- replace the infinite-loop-plus-recover indicator test helper with a finite loop
- preserve existing four-decimal rounding behavior
- make modern go vet pass on the test package

## Validation
- GOCACHE=/private/tmp/techan-gocache mise x go@1.26.3 -- go test ./...
- GOCACHE=/private/tmp/techan-gocache mise x go@1.26.3 -- go vet ./...

Stacked on #65.